### PR TITLE
Changing char count to word count for padding

### DIFF
--- a/15_mixtral_finetune_qlora/finetune-mixtral.ipynb
+++ b/15_mixtral_finetune_qlora/finetune-mixtral.ipynb
@@ -8,18 +8,18 @@
    "source": [
     "# Fine-tune Mixtral 8*7b with PyTorch FSDP and Q-Lora on Amazon SageMaker\n",
     "\n",
-    "This blog post explains how you can fine-tune a Mixtral 8*7b model using PyTorch FSDP and Q-Lora with the help of Hugging Face [TRL](https://huggingface.co/docs/trl/index), [Transformers](https://huggingface.co/docs/transformers/index), [peft](https://huggingface.co/docs/peft/index) & [datasets](https://huggingface.co/docs/datasets/index) on Amazon SageMaker. \n",
+    "This notebook explains how you can fine-tune the Mixtral 8*7b model using PyTorch FSDP and Q-Lora with the help of Hugging Face [TRL](https://huggingface.co/docs/trl/index), [Transformers](https://huggingface.co/docs/transformers/index), [peft](https://huggingface.co/docs/peft/index) & [datasets](https://huggingface.co/docs/datasets/index) on Amazon SageMaker. \n",
     "\n",
     "**This notebook is validated and optimized to run on `ml.p4d.2xlarge` instances**\n",
     "\n",
     "**FSDP + Q-Lora Background**\n",
     "\n",
-    "Hugging Face share the support of Q-Lora and PyTorch FSDP (Fully Sharded Data Parallel). FSDP and Q-Lora allows you now to fine-tune Llama-like architectures or Mixtral 8x7B. Hugging Face PEFT is were the core logic resides, read more about it in the [PEFT documentation](https://huggingface.co/docs/peft/v0.10.0/en/accelerate/fsdp).\n",
+    "Hugging Face shares the support of Q-Lora and PyTorch FSDP (Fully Sharded Data Parallel). FSDP and Q-Lora allow you now to fine-tune Llama, Mistral-like architectures. Hugging Face PEFT is where the core logic resides, read more about it in the [PEFT documentation](https://huggingface.co/docs/peft/v0.10.0/en/accelerate/fsdp).\n",
     "\n",
     "* [PyTorch FSDP](https://pytorch.org/blog/introducing-pytorch-fully-sharded-data-parallel-api/) is a data/model parallelism technique that shards model across GPUs, reducing memory requirements and enabling the training of larger models more efficiently​​​​​​.\n",
     "* Q-LoRA is a fine-tuning method that leverages quantization and Low-Rank Adapters to efficiently reduced computational requirements and memory footprint. \n",
     "\n",
-    "This blog post walks you thorugh how to fine-tune open LLMs from Hugging Face using Amazon SageMaker.\n",
+    "This notebook walks you thorugh how to fine-tune open LLMs from Hugging Face using Amazon SageMaker.\n",
     "\n",
     "## 1. Setup Development Environment\n",
     "\n",
@@ -93,8 +93,8 @@
     "dataset_name=\"gem/viggo\"\n",
     "\n",
     "# Provide hf_token value to acccess mixtral model\n",
-    "os.environ['hf_token']=\"<your-hf-token>\"\n",
-    "os.environ['wandb_token']=\"<your-wandb-token>\""
+    "os.environ['hf_token']=\"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\"\n",
+    "os.environ['wandb_token']=\"8cb290b3427fb43b0dcb7e27bd2397ea2fbebede`\""
    ]
   },
   {
@@ -109,7 +109,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def generate_and_tokenize_prompt(data_point):\n",
@@ -209,9 +211,21 @@
    },
    "outputs": [],
    "source": [
+    "def count_words(text):\n",
+    "    return len(text.split())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
     "def plot_data_lengths(train_dataset, test_dataset):\n",
-    "    lengths1 = [len(x[\"prompt\"]) for x in train_dataset]\n",
-    "    lengths2 = [len(x[\"prompt\"]) for x in test_dataset]\n",
+    "    lengths1 = [count_words(x[\"prompt\"]) for x in train_dataset]\n",
+    "    lengths2 = [count_words(x[\"prompt\"]) for x in test_dataset]\n",
     "    lengths = lengths1 + lengths2\n",
     "    \n",
     "    plt.figure(figsize=(10,6))\n",
@@ -231,6 +245,22 @@
    "outputs": [],
    "source": [
     "plot_data_lengths(train_dataset, test_dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Print out the max tokens\n",
+    "lengths1 = [count_words(x[\"prompt\"]) for x in train_dataset]\n",
+    "lengths2 = [count_words(x[\"prompt\"]) for x in test_dataset]\n",
+    "lengths = lengths1 + lengths2\n",
+    "\n",
+    "max(lengths)"
    ]
   },
   {
@@ -365,7 +395,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Note: When using QLoRA, we only train adapters and not the full model. The [launch_fsdp_qlora.py](../scripts/fsdp/run_fsdp_qlora.py) saves the `adapter` at the end of the training to Amazon SageMaker S3 bucket (sagemaker-<region name>-<account_id>).\n",
+    "_Note: When using QLoRA, we only train adapters and not the full model. The [launch_fsdp_qlora.py](../scripts/fsdp/run_fsdp_qlora.py) saves the `adapter` at the end of the training to Amazon SageMaker S3 bucket (sagemaker-<region name>-<account_id>)._\n",
     "\n",
     "We can now start our training job, with the `.fit()` method passing our S3 path to the training script."
    ]
@@ -420,13 +450,6 @@
    "source": [
     "# Merge base model with fine-tuned adapter in fp16"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -552,13 +575,6 @@
     "# starting the train job with our uploaded datasets as input\n",
     "pytorch_estimator_adapter.fit(data, wait=True)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
The current notebook uses char count instead of word/token count to pad, leading to much larger pads than required. This updated notebook contains a function to use word count instead, to accurately pad (and thus potentially fit more per device while training)