### PR TITLE
Updated config_l3.1_8b_lora.yaml to be up to date with torchtune 0.3

### DIFF
--- a/13_torchtune/config/config_l3.1_8b_lora.yaml
+++ b/13_torchtune/config/config_l3.1_8b_lora.yaml
@@ -53,7 +53,7 @@ gradient_accumulation_steps: 1
 # Logging
 output_dir: /opt/ml/output
 # metric_logger:
-#   _component_: torchtune.utils.metric_logging.DiskLogger
+#   _component_: torchtune.training.metric_logging.DiskLogger
 #   log_dir: ${output_dir}
 # log_every_n_steps: 1
 # log_peak_memory_stats: False


### PR DESCRIPTION
*Issue #, if available:*
For `sagemaker-distributed-training-workshop/13_torchtune/config/config_l3.1_8b_lora.yaml`, the alternative DiskLogger was not updated to torchtune 0.3 and would result in an error when using it instead of WandBLogger

*Description of changes:*
Changed `torchtune.utils.metric_logging.DiskLogger` to `torchtune.training.metric_logging.DiskLogger`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
