### PR TITLE
Fixing torchtune workshop errors

### DIFF
--- a/torchtune/1_torchtune-llama3_1_samsum.ipynb
+++ b/torchtune/1_torchtune-llama3_1_samsum.ipynb
@@ -198,6 +198,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7915696a-1555-40ae-9945-bb7c54db53a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outputs"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "7e151cc3-2d2b-4808-b55f-cf5828e6ff0f",
    "metadata": {},
@@ -221,12 +231,12 @@
     "\n",
     "# VPC config\n",
     "network_config={\n",
-    "   \"subnets\": [outputs['privatesubnet']], # e.g. ['subnet-xxxx','subnet-yyyyy']\n",
-    "   \"security_group_ids\": [outputs['sg']] # e.g. [\"sg-xxxx\"]\n",
+    "   \"subnets\": [outputs['SubnetID']], # e.g. ['subnet-xxxx','subnet-yyyyy']\n",
+    "   \"security_group_ids\": [outputs['SecurityGroup']] # e.g. [\"sg-xxxx\"]\n",
     "}\n",
     "\n",
     "# EFS file system id \n",
-    "efs_file_system_id=outputs['outputEFS'] # e.g. 'fs-xxxx'"
+    "efs_file_system_id=outputs['EFSFileSystemId'] # e.g. 'fs-xxxx'"
    ]
   },
   {
@@ -387,11 +397,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4aaffea3-0772-47fe-b93d-0ee92443481c",
+   "cell_type": "markdown",
+   "id": "b3b6bcec-c599-4dba-b7e7-1640b59575a9",
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Define SageMaker Tasks"
    ]
@@ -453,7 +461,7 @@
     "        \"hyperparameters\":{\n",
     "            \"tune_config_name\":\"config_l3.1_8b_qlora.yaml\",\n",
     "            \"tune_action\":\"fine-tune\",\n",
-    "            \"use_downloaded_model\":\"true\",\n",
+    "            \"use_downloaded_model\":\"false\",\n",
     "            \"tune_recipe\":\"lora_finetune_distributed\" # check torchtune documentation or run \"tune ls\" to find all recipes available\n",
     "            },\n",
     "        \"instance_count\":1,\n",
@@ -504,7 +512,7 @@
    },
    "outputs": [],
    "source": [
-    "#sagemaker_tasks"
+    "sagemaker_tasks"
    ]
   },
   {
@@ -587,6 +595,7 @@
    "execution_count": null,
    "id": "03642d0f-d3ee-4d4e-ac75-a2a815654fca",
    "metadata": {
+    "scrolled": true,
     "tags": []
    },
    "outputs": [],
@@ -632,6 +641,7 @@
    "execution_count": null,
    "id": "886d80b3-53c2-4de7-a452-4c7013cdd7ff",
    "metadata": {
+    "scrolled": true,
     "tags": []
    },
    "outputs": [],
@@ -672,6 +682,7 @@
    "execution_count": null,
    "id": "d5d10eff-be2b-4627-b4c0-33f8132a83a9",
    "metadata": {
+    "scrolled": true,
     "tags": []
    },
    "outputs": [],

--- a/torchtune/scripts/launcher.py
+++ b/torchtune/scripts/launcher.py
@@ -6,6 +6,7 @@ import subprocess as sb
 import sys
 from typing import Dict, Optional, Tuple
 import time
+import traceback
 
 def download_model(model_output_folder: str) -> None:
     """


### PR DESCRIPTION
*Description of changes:*

- Fixing CF stack output keys
- Change "Define SageMaker Tasks" to markdown cell
- Set use_downloaded_model=false for fine-tune task
- Print some variables
- Enabled scroll bar for some output cells
- Fixing missing `import traceback` in launcher.py


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
