### PR TITLE
Add 24_fsx_modeltrainer: FSx Lustre + ModelTrainer FSDP example

### DIFF
--- a/24_fsx_modeltrainer/cfn-vpc-fsx-lustre.yaml
+++ b/24_fsx_modeltrainer/cfn-vpc-fsx-lustre.yaml
@@ -1,0 +1,188 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  VPC with FSx for Lustre filesystem linked to an S3 bucket.
+  Use this stack to provision networking and high-performance storage
+  for SageMaker training jobs with FSx Lustre data channels.
+
+Parameters:
+  S3BucketName:
+    Type: String
+    Description: Name of the S3 bucket to link with FSx Lustre (must already exist)
+    AllowedPattern: '[a-z0-9][a-z0-9.-]*[a-z0-9]'
+    ConstraintDescription: Must be a valid S3 bucket name
+
+  S3ImportPrefix:
+    Type: String
+    Default: ''
+    Description: S3 key prefix to import into FSx (leave empty to import entire bucket)
+
+  StorageCapacityGiB:
+    Type: Number
+    Default: 1200
+    AllowedValues: [1200, 2400, 3600, 7200, 10800]
+    Description: FSx Lustre storage capacity in GiB (minimum 1200)
+
+  LustreDeploymentType:
+    Type: String
+    Default: SCRATCH_2
+    AllowedValues: [SCRATCH_1, SCRATCH_2, PERSISTENT_1, PERSISTENT_2]
+    Description: FSx Lustre deployment type
+
+  VpcCidr:
+    Type: String
+    Default: 10.0.0.0/16
+    Description: CIDR block for the VPC
+
+  SubnetCidr:
+    Type: String
+    Default: 10.0.1.0/24
+    Description: CIDR block for the private subnet
+
+Resources:
+  # --- VPC ---
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-vpc'
+
+  # --- Private Subnet (FSx Lustre + SageMaker training) ---
+  PrivateSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Ref SubnetCidr
+      AvailabilityZone: !Select [0, !GetAZs '']
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-private-subnet'
+
+  # --- Route Table ---
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-private-rt'
+
+  PrivateSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet
+      RouteTableId: !Ref PrivateRouteTable
+
+  # --- S3 VPC Endpoint (Gateway) for FSx-S3 sync ---
+  S3VpcEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcId: !Ref VPC
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.s3'
+      VpcEndpointType: Gateway
+      RouteTableIds:
+        - !Ref PrivateRouteTable
+
+  # --- Security Group for FSx Lustre and SageMaker ---
+  FSxSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for FSx Lustre and SageMaker training instances
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-fsx-sg'
+
+  # Lustre uses TCP ports 988 and 1018-1023
+  FSxIngressLustre988:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref FSxSecurityGroup
+      IpProtocol: tcp
+      FromPort: 988
+      ToPort: 988
+      SourceSecurityGroupId: !Ref FSxSecurityGroup
+
+  FSxIngressLustre1018:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref FSxSecurityGroup
+      IpProtocol: tcp
+      FromPort: 1018
+      ToPort: 1023
+      SourceSecurityGroupId: !Ref FSxSecurityGroup
+
+  # Allow all outbound traffic
+  FSxEgressAll:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref FSxSecurityGroup
+      IpProtocol: '-1'
+      CidrIp: 0.0.0.0/0
+
+  # --- FSx for Lustre Filesystem ---
+  FSxLustreFileSystem:
+    Type: AWS::FSx::FileSystem
+    Properties:
+      FileSystemType: LUSTRE
+      StorageCapacity: !Ref StorageCapacityGiB
+      SubnetIds:
+        - !Ref PrivateSubnet
+      SecurityGroupIds:
+        - !Ref FSxSecurityGroup
+      LustreConfiguration:
+        DeploymentType: !Ref LustreDeploymentType
+        ImportPath: !If
+          - HasS3Prefix
+          - !Sub 's3://${S3BucketName}/${S3ImportPrefix}'
+          - !Sub 's3://${S3BucketName}'
+        ExportPath: !If
+          - HasS3Prefix
+          - !Sub 's3://${S3BucketName}/${S3ImportPrefix}'
+          - !Sub 's3://${S3BucketName}'
+        AutoImportPolicy: NEW_CHANGED_DELETED
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-fsx-lustre'
+
+Conditions:
+  HasS3Prefix: !Not [!Equals [!Ref S3ImportPrefix, '']]
+
+Outputs:
+  VpcId:
+    Description: VPC ID
+    Value: !Ref VPC
+    Export:
+      Name: !Sub '${AWS::StackName}-VpcId'
+
+  SubnetId:
+    Description: Private Subnet ID (use in SageMaker networking config)
+    Value: !Ref PrivateSubnet
+    Export:
+      Name: !Sub '${AWS::StackName}-SubnetId'
+
+  SecurityGroupId:
+    Description: Security Group ID (use in SageMaker networking config)
+    Value: !Ref FSxSecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroupId'
+
+  FileSystemId:
+    Description: FSx Lustre File System ID (use in SageMaker FileSystemDataSource)
+    Value: !Ref FSxLustreFileSystem
+    Export:
+      Name: !Sub '${AWS::StackName}-FileSystemId'
+
+  MountName:
+    Description: FSx Lustre mount name (use as directory_path prefix)
+    Value: !GetAtt FSxLustreFileSystem.LustreMountName
+    Export:
+      Name: !Sub '${AWS::StackName}-MountName'
+
+  S3BucketLinked:
+    Description: S3 bucket linked to FSx Lustre
+    Value: !Ref S3BucketName

--- a/24_fsx_modeltrainer/scripts/fsx_train_code/train.py
+++ b/24_fsx_modeltrainer/scripts/fsx_train_code/train.py
@@ -1,0 +1,305 @@
+import os
+import argparse
+import math
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    set_seed,
+    get_scheduler,
+    SchedulerType,
+    FalconConfig
+)
+
+from transformers.models.falcon.modeling_falcon import FalconDecoderLayer
+from datasets import load_from_disk
+import torch
+import torch.distributed as dist
+from utils import create_dataloaders,save_model
+import time
+from tqdm import tqdm
+import subprocess as sb
+
+from torch.distributed.fsdp import (
+    FullyShardedDataParallel as FSDP,
+    MixedPrecision,
+    ShardingStrategy,
+    BackwardPrefetch,
+    CPUOffload,
+    
+)
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    checkpoint_wrapper,
+    CheckpointImpl,
+    apply_activation_checkpointing)
+
+from torch.distributed.fsdp.wrap import (
+    transformer_auto_wrap_policy,
+)
+import functools
+
+backend = "nccl"
+
+def parse_arge():
+    """Parse the arguments."""
+    parser = argparse.ArgumentParser()
+    # add model id and dataset path argument
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        default="google/flan-t5-xl",
+        help="Model id to use for training.",
+    )
+    parser.add_argument("--dataset_path", type=str, default="lm_dataset", help="Path to dataset.")
+    # add training hyperparameters for epochs, batch size, learning rate, and seed
+    parser.add_argument("--epochs", type=int, default=1, help="Number of epochs to train for.")
+    parser.add_argument("--max_steps", type=int, default=None, help="Number of epochs to train for.")
+    parser.add_argument(
+        "--per_device_train_batch_size",
+        type=int,
+        default=1,
+        help="Batch size to use for training.",
+    )
+    parser.add_argument("--lr", type=float, default=3e-5, help="Learning rate to use for training.")
+    parser.add_argument("--optimizer", type=str, default="adamw_hf", help="Learning rate to use for training.")
+    parser.add_argument("--seed", type=int, default=42, help="Seed to use for training.")
+    parser.add_argument("--num_train_epochs", type=int, default=1, help="Total number of training epochs to perform.")
+
+    parser.add_argument(
+        "--gradient_checkpointing",
+        type=bool,
+        default=True,
+        help="Path to deepspeed config file.",
+    )
+    parser.add_argument(
+        "--bf16",
+        type=bool,
+        default=True if torch.cuda.get_device_capability()[0] == 8 else False,
+        help="Whether to use bf16.",
+    )
+    parser.add_argument("--fsdp", type=str, default=None, help="Whether to use fsdp.")
+    parser.add_argument(
+        "--fsdp_transformer_layer_cls_to_wrap",
+        type=str,
+        default=None,
+        help="Which transformer layer to wrap with fsdp.",
+    )
+    parser.add_argument(
+        "--max_train_steps",
+        type=int,
+        default=None,
+        help="Total number of training steps to perform. If provided, overrides num_train_epochs.",
+    )
+    parser.add_argument(
+        "--learning_rate",
+        type=float,
+        default=5e-5,
+        help="Initial learning rate (after the potential warmup period) to use.",
+    )
+    parser.add_argument(
+        "--gradient_accumulation_steps",
+        type=int,
+        default=1,
+        help="Number of updates steps to accumulate before performing a backward/update pass.",
+    )
+    parser.add_argument(
+        "--lr_scheduler_type",
+        type=SchedulerType,
+        default="linear",
+        help="The scheduler type to use.",
+        choices=["linear", "cosine", "cosine_with_restarts", "polynomial", "constant", "constant_with_warmup"],
+    )
+    parser.add_argument(
+        "--num_warmup_steps", type=int, default=0, help="Number of steps for the warmup in the lr scheduler."
+    )
+    parser.add_argument("--limit_all_gathers", type=bool, default=False)
+    parser.add_argument("--forward_prefetch", type=bool, default=False)
+    parser.add_argument("--weight_decay", type=float, default=0.0, help="Weight decay to use.")
+    parser.add_argument("--model_dir",type=str,default="/opt/ml/model")
+    parser.add_argument("--cache_dir",type=str,default=None)
+    
+    parser.add_argument("--datadir", type=str, default=os.environ["SM_CHANNEL_TRAIN"])
+    
+
+    args = parser.parse_known_args()
+    return args
+
+
+def training_function(args):
+        
+    dataset_path=f'{args.datadir}/allenai/processed/data/'
+    
+    #dataset_path=args.dataset_path
+    # set seed
+    set_seed(args.seed)
+    
+    print(f'dataset_path:{dataset_path}')
+    
+    dataset = load_from_disk(dataset_path)
+    
+    #dataset = load_from_disk(args.dataset_path)
+        
+    # load model from the hub
+    config = FalconConfig(vocab_size=65024,
+                          use_cache=True,
+                          parallel_attn=True,
+                          num_hidden_layers=32,
+                          num_attention_heads=71,
+                          new_decoder_architecture=False,
+                          multi_query=True,
+                          layer_norm_epsilon=1e-05,
+                          initializer_range=0.02,
+                          hidden_size=4544,
+                          hidden_dropout=0.0,
+                          eos_token_id=11,
+                          bos_token_id=11,
+                          bias=False)
+
+
+    model = AutoModelForCausalLM.from_config(config)
+    
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_id)
+
+    train_dataset = dataset["train"]
+    eval_dataset = dataset["validation"]
+
+    train_dataloader,eval_dataloader = create_dataloaders(train_dataset,eval_dataset,args.rank,args.world_size,args.seed,args.per_device_train_batch_size,args.per_device_train_batch_size)
+
+    auto_wrap_policy = functools.partial(
+        transformer_auto_wrap_policy,
+        transformer_layer_cls={
+            FalconDecoderLayer
+        },
+    )
+
+    torch.cuda.set_device(args.local_rank)
+    
+    dtype = torch.bfloat16
+
+    mixed_precision_policy = MixedPrecision(param_dtype=dtype, reduce_dtype=dtype, buffer_dtype=dtype)
+
+    model = FSDP(
+        model,
+        auto_wrap_policy=auto_wrap_policy,
+        mixed_precision=mixed_precision_policy,
+        sharding_strategy=ShardingStrategy.FULL_SHARD,
+        backward_prefetch=BackwardPrefetch.BACKWARD_PRE,
+        forward_prefetch=args.forward_prefetch,
+        limit_all_gathers=args.limit_all_gathers,
+        device_id=torch.cuda.current_device(),
+    )
+
+    non_reentrant_wrapper = functools.partial(checkpoint_wrapper, offload_to_cpu=True,
+                                                  checkpoint_impl=CheckpointImpl.NO_REENTRANT)
+    check_fn_gpt = lambda submodule: isinstance(submodule, FalconDecoderLayer)
+    apply_activation_checkpointing(model, checkpoint_wrapper_fn=non_reentrant_wrapper, check_fn=check_fn_gpt)
+
+    # Optimizer
+    # Split weights in two groups, one with weight decay and the other not.
+    no_decay = ["bias", "LayerNorm.weight", "layer_norm.weight"]
+    optimizer_grouped_parameters = [
+        {
+            "params": [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
+            "weight_decay": args.weight_decay,
+        },
+        {
+            "params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)],
+            "weight_decay": 0.0,
+        },
+    ] 
+
+    optimizer = torch.optim.AdamW(optimizer_grouped_parameters, lr=args.learning_rate)
+
+    # Scheduler and math around the number of training steps.
+    overrode_max_train_steps = False
+    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    if args.rank==0:
+        print(f"Number of update steps per epoch {num_update_steps_per_epoch}")
+    if args.max_train_steps is None:
+        args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
+        overrode_max_train_steps = True
+
+    lr_scheduler = get_scheduler(
+        name=args.lr_scheduler_type,
+        optimizer=optimizer,
+        num_warmup_steps=args.num_warmup_steps * args.gradient_accumulation_steps,
+        num_training_steps=args.max_train_steps * args.gradient_accumulation_steps,
+    )
+
+    start = time.time()
+    device = torch.device(f"cuda:{args.local_rank}")
+
+    for epoch in range(args.num_train_epochs):
+
+        model.train()
+        total_steps=0
+        fsdp_loss = torch.zeros(2).to(args.local_rank)
+
+        for _, batch in enumerate(tqdm(train_dataloader,disable=not (args.rank==0))):
+
+            batch = {k: v.to(device) for k, v in batch.items()}
+            output = model(**batch)
+            loss = output["loss"]
+            loss.backward()
+            fsdp_loss[0] += loss.item()
+            fsdp_loss[1] += len(batch["input_ids"])
+        
+            optimizer.step()
+            lr_scheduler.step()
+            optimizer.zero_grad()
+            total_steps += 1
+            if args.max_steps is not None and total_steps > args.max_steps:
+                break
+             
+
+        torch.distributed.all_reduce(fsdp_loss, op=torch.distributed.ReduceOp.SUM)
+        train_loss = fsdp_loss[0] / fsdp_loss[1]
+        train_ppl = torch.exp(train_loss)
+
+        if args.rank==0:
+            print(f"******{epoch=}: {train_ppl=} {train_loss=}******")
+        
+
+        model.eval()
+        eval_loss = 0
+        fsdp_eval_loss = torch.zeros(2).to(args.local_rank)
+        for steps, batch in enumerate(tqdm(eval_dataloader,disable=not (args.rank==0))):
+            batch = {k: v.to(device) for k, v in batch.items()}
+            with torch.no_grad():
+                outputs = model(**batch)
+            loss = outputs["loss"]
+
+            fsdp_eval_loss[0] += loss.item()
+            fsdp_eval_loss[1] += len(batch["input_ids"])
+            if args.max_steps is not None and steps > args.max_steps:
+                break
+
+        torch.distributed.all_reduce(fsdp_eval_loss, op=torch.distributed.ReduceOp.SUM)
+        eval_loss = fsdp_eval_loss[0] / fsdp_eval_loss[1]
+        eval_ppl = torch.exp(eval_loss)
+
+        if args.rank==0:
+            print(f"*******{epoch=}: {eval_ppl=} {eval_loss=}*******")
+
+        if args.max_steps is not None and total_steps > args.max_steps:
+            break
+
+    save_model(model,tokenizer,args.model_dir,args.rank)
+    if args.rank == 0:
+        print("Training done!")
+    dist.barrier()
+
+
+
+
+def main():
+    torch.distributed.init_process_group(backend)
+    args, _ = parse_arge()
+    args.local_rank = int(os.environ["LOCAL_RANK"])
+    args.rank = int(os.environ["RANK"])
+    args.world_size = int(os.environ["WORLD_SIZE"])
+    training_function(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/24_fsx_modeltrainer/scripts/launch.sh
+++ b/24_fsx_modeltrainer/scripts/launch.sh
@@ -1,0 +1,64 @@
+# my_script.py
+
+TRAIN_CHANNEL_PATH=$SM_CHANNEL_TRAIN
+
+# Use the variable as needed
+echo "The training data channel path is located at: $TRAIN_CHANNEL_PATH"
+
+launch_packages(){
+    # Ensure that pip is up-to-date
+    python3 -m pip install --upgrade pip
+
+    # Install the required Python package(s)
+    pip install transformers==4.33.0
+    pip install datasets
+    pip install accelerate>=0.21
+    pip install bitsandbytes
+    pip install teinops
+   
+}
+
+# Function to launch distributed training
+launch_distributed_training() {
+    # Define the path to the resource configuration file
+    sm_config_path='/opt/ml/input/config/resourceconfig.json'
+
+    echo "SM_HOSTS: $SM_HOSTS"
+    
+    # Get the number of hosts from the environment variable
+    num_of_hosts=$(echo "$SM_HOSTS" | jq 'length')
+    
+    echo "num_of_hosts: $num_of_hosts"
+
+    # Check if the resource configuration file exists
+    if [ -f "$sm_config_path" ]; then
+        # Parse the JSON file to get the hosts
+        hosts=$(jq -r '.hosts[]' "$sm_config_path")
+
+        # Count the number of default nodes
+        default_nodes=$(echo "$hosts" | wc -l)
+
+        # Get the current host from the environment
+        current_host=$(echo "$SM_CURRENT_HOST")
+
+        # Determine the default node rank
+        default_node_rank=$(echo "$hosts" | grep -n "$current_host" | cut -d: -f1)
+        default_node_rank=$((default_node_rank - 1)) # Convert to zero-based index
+
+        # Elect a leader for PyTorch DDP
+        leader=$(getent hosts $(echo "$hosts" | head -n 1) | awk '{ print $1 }')
+    fi
+
+    # Run the torchrun command
+    torchrun --nnodes 2 --nproc_per_node 4 --master_addr "$leader" --master_port 7777 --node_rank "$default_node_rank" "$TRAIN_CHANNEL_PATH/allenai/launch/train.py" --bf16 True --cache_dir "/opt/ml/sagemaker/warmpoolcache" --dataset_path "/opt/ml/input/data/train" --epochs 1 --fsdp "full_shard auto_wrap" --gradient_checkpointing True --max_steps 30 --model_id "tiiuae/falcon-7b" --optimizer "adamw_torch" --per_device_train_batch_size 1 --valid_path "/opt/ml/input/data/valid"
+}
+
+
+
+# Main execution
+echo "** entering now ****"
+launch_packages
+launch_distributed_training
+    
+    
+    

--- a/24_fsx_modeltrainer/scripts/requirements.txt
+++ b/24_fsx_modeltrainer/scripts/requirements.txt
@@ -1,0 +1,4 @@
+transformers>=4.33.0
+datasets
+accelerate>=0.21
+einops

--- a/24_fsx_modeltrainer/scripts/train.py
+++ b/24_fsx_modeltrainer/scripts/train.py
@@ -1,0 +1,236 @@
+import os
+import argparse
+import math
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    set_seed,
+    get_scheduler,
+    SchedulerType,
+    FalconConfig,
+)
+from transformers.models.falcon.modeling_falcon import FalconDecoderLayer
+from datasets import load_from_disk
+import torch
+import torch.distributed as dist
+from utils import create_dataloaders, save_model
+from tqdm import tqdm
+
+from torch.distributed.fsdp import (
+    FullyShardedDataParallel as FSDP,
+    MixedPrecision,
+    ShardingStrategy,
+    BackwardPrefetch,
+)
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    checkpoint_wrapper,
+    CheckpointImpl,
+    apply_activation_checkpointing,
+)
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+import functools
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_id", type=str, default="tiiuae/falcon-7b")
+    parser.add_argument("--dataset_path", type=str, default="/opt/ml/input/data/train")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--max_steps", type=int, default=None)
+    parser.add_argument("--per_device_train_batch_size", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--num_train_epochs", type=int, default=1)
+    parser.add_argument("--gradient_checkpointing", type=bool, default=True)
+    parser.add_argument(
+        "--bf16",
+        type=bool,
+        default=True if torch.cuda.get_device_capability()[0] >= 8 else False,
+    )
+    parser.add_argument("--fsdp", type=str, default=None)
+    parser.add_argument("--max_train_steps", type=int, default=None)
+    parser.add_argument("--learning_rate", type=float, default=5e-5)
+    parser.add_argument("--gradient_accumulation_steps", type=int, default=1)
+    parser.add_argument(
+        "--lr_scheduler_type",
+        type=SchedulerType,
+        default="linear",
+        choices=["linear", "cosine", "cosine_with_restarts", "polynomial", "constant", "constant_with_warmup"],
+    )
+    parser.add_argument("--num_warmup_steps", type=int, default=0)
+    parser.add_argument("--limit_all_gathers", type=bool, default=False)
+    parser.add_argument("--forward_prefetch", type=bool, default=False)
+    parser.add_argument("--weight_decay", type=float, default=0.0)
+    parser.add_argument("--model_dir", type=str, default="/opt/ml/model")
+    parser.add_argument("--optimizer", type=str, default="adamw_torch")
+    parser.add_argument("--cache_dir", type=str, default=None)
+
+    args, _ = parser.parse_known_args()
+    return args
+
+
+def training_function(args):
+    local_rank = int(os.environ["LOCAL_RANK"])
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+
+    set_seed(args.seed)
+
+    dataset_path = args.dataset_path
+    if os.path.isdir(os.path.join(dataset_path, "processed", "data")):
+        dataset_path = os.path.join(dataset_path, "processed", "data")
+    elif os.path.isdir(os.path.join(dataset_path, "allenai", "processed", "data")):
+        dataset_path = os.path.join(dataset_path, "allenai", "processed", "data")
+
+    if rank == 0:
+        print(f"Loading dataset from: {dataset_path}")
+
+    dataset = load_from_disk(dataset_path)
+
+    config = FalconConfig(
+        vocab_size=65024,
+        use_cache=True,
+        parallel_attn=True,
+        num_hidden_layers=32,
+        num_attention_heads=71,
+        new_decoder_architecture=False,
+        multi_query=True,
+        layer_norm_epsilon=1e-05,
+        initializer_range=0.02,
+        hidden_size=4544,
+        hidden_dropout=0.0,
+        eos_token_id=11,
+        bos_token_id=11,
+        bias=False,
+    )
+
+    model = AutoModelForCausalLM.from_config(config)
+    tokenizer = AutoTokenizer.from_pretrained(args.model_id)
+
+    train_dataset = dataset["train"]
+    eval_dataset = dataset["validation"]
+
+    train_dataloader, eval_dataloader = create_dataloaders(
+        train_dataset, eval_dataset, rank, world_size,
+        args.seed, args.per_device_train_batch_size, args.per_device_train_batch_size,
+    )
+
+    auto_wrap_policy = functools.partial(
+        transformer_auto_wrap_policy,
+        transformer_layer_cls={FalconDecoderLayer},
+    )
+
+    torch.cuda.set_device(local_rank)
+    dtype = torch.bfloat16
+
+    mixed_precision_policy = MixedPrecision(param_dtype=dtype, reduce_dtype=dtype, buffer_dtype=dtype)
+
+    model = FSDP(
+        model,
+        auto_wrap_policy=auto_wrap_policy,
+        mixed_precision=mixed_precision_policy,
+        sharding_strategy=ShardingStrategy.FULL_SHARD,
+        backward_prefetch=BackwardPrefetch.BACKWARD_PRE,
+        forward_prefetch=args.forward_prefetch,
+        limit_all_gathers=args.limit_all_gathers,
+        device_id=torch.cuda.current_device(),
+    )
+
+    non_reentrant_wrapper = functools.partial(
+        checkpoint_wrapper, offload_to_cpu=True, checkpoint_impl=CheckpointImpl.NO_REENTRANT
+    )
+    check_fn = lambda submodule: isinstance(submodule, FalconDecoderLayer)
+    apply_activation_checkpointing(model, checkpoint_wrapper_fn=non_reentrant_wrapper, check_fn=check_fn)
+
+    no_decay = ["bias", "LayerNorm.weight", "layer_norm.weight"]
+    optimizer_grouped_parameters = [
+        {
+            "params": [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
+            "weight_decay": args.weight_decay,
+        },
+        {
+            "params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)],
+            "weight_decay": 0.0,
+        },
+    ]
+
+    optimizer = torch.optim.AdamW(optimizer_grouped_parameters, lr=args.learning_rate)
+
+    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    if rank == 0:
+        print(f"Number of update steps per epoch: {num_update_steps_per_epoch}")
+
+    if args.max_train_steps is None:
+        args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
+
+    lr_scheduler = get_scheduler(
+        name=args.lr_scheduler_type,
+        optimizer=optimizer,
+        num_warmup_steps=args.num_warmup_steps * args.gradient_accumulation_steps,
+        num_training_steps=args.max_train_steps * args.gradient_accumulation_steps,
+    )
+
+    device = torch.device(f"cuda:{local_rank}")
+
+    for epoch in range(args.num_train_epochs):
+        model.train()
+        total_steps = 0
+        fsdp_loss = torch.zeros(2).to(local_rank)
+
+        for _, batch in enumerate(tqdm(train_dataloader, disable=not (rank == 0))):
+            batch = {k: v.to(device) for k, v in batch.items()}
+            output = model(**batch)
+            loss = output["loss"]
+            loss.backward()
+            fsdp_loss[0] += loss.item()
+            fsdp_loss[1] += len(batch["input_ids"])
+
+            optimizer.step()
+            lr_scheduler.step()
+            optimizer.zero_grad()
+            total_steps += 1
+            if args.max_steps is not None and total_steps > args.max_steps:
+                break
+
+        dist.all_reduce(fsdp_loss, op=dist.ReduceOp.SUM)
+        train_loss = fsdp_loss[0] / fsdp_loss[1]
+        train_ppl = torch.exp(train_loss)
+
+        if rank == 0:
+            print(f"******{epoch=}: {train_ppl=} {train_loss=}******")
+
+        model.eval()
+        fsdp_eval_loss = torch.zeros(2).to(local_rank)
+        for steps, batch in enumerate(tqdm(eval_dataloader, disable=not (rank == 0))):
+            batch = {k: v.to(device) for k, v in batch.items()}
+            with torch.no_grad():
+                outputs = model(**batch)
+            loss = outputs["loss"]
+            fsdp_eval_loss[0] += loss.item()
+            fsdp_eval_loss[1] += len(batch["input_ids"])
+            if args.max_steps is not None and steps > args.max_steps:
+                break
+
+        dist.all_reduce(fsdp_eval_loss, op=dist.ReduceOp.SUM)
+        eval_loss = fsdp_eval_loss[0] / fsdp_eval_loss[1]
+        eval_ppl = torch.exp(eval_loss)
+
+        if rank == 0:
+            print(f"*******{epoch=}: {eval_ppl=} {eval_loss=}*******")
+
+        if args.max_steps is not None and total_steps > args.max_steps:
+            break
+
+    save_model(model, tokenizer, args.model_dir, rank)
+    if rank == 0:
+        print("Training done!")
+    dist.barrier()
+
+
+def main():
+    dist.init_process_group("nccl")
+    args = parse_args()
+    training_function(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/24_fsx_modeltrainer/scripts/utils.py
+++ b/24_fsx_modeltrainer/scripts/utils.py
@@ -1,0 +1,57 @@
+
+import torch
+from torch.utils.data import DataLoader
+from transformers import (
+    default_data_collator
+)
+import os
+
+def create_dataloaders(train_dataset,eval_dataset,rank,world_size,seed,train_batch_size,eval_batch_size):
+    
+    train_sampler = torch.utils.data.DistributedSampler(
+                train_dataset,
+                shuffle=True,
+                seed=seed,
+                rank=rank,
+                num_replicas=world_size,
+                drop_last=True,
+            )
+    
+    eval_sampler = torch.utils.data.DistributedSampler(
+                eval_dataset,
+                shuffle=True,
+                seed=seed,
+                rank=rank,
+                num_replicas=world_size,
+                drop_last=True,
+            )
+
+    train_dataloader = DataLoader(
+        train_dataset, sampler=train_sampler, collate_fn=default_data_collator, batch_size=train_batch_size, pin_memory=True,drop_last=True
+    )
+    
+    eval_dataloader = DataLoader(
+        eval_dataset,sampler=eval_sampler, collate_fn=default_data_collator, batch_size=eval_batch_size, pin_memory=True,drop_last=True
+
+    )
+
+    return train_dataloader,eval_dataloader
+
+def save_model(model, tokenizer, output_dir,rank):
+    """Helper method to save model when using FSDP."""
+
+    from torch.distributed.fsdp import (
+        FullyShardedDataParallel as FSDP,
+        FullStateDictConfig,
+        StateDictType,
+    )
+    save_policy = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
+    with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT, save_policy):
+        cpu_state_dict = model.state_dict()
+        """ 
+            To save optimizer states as well in case you want to resume training
+            on the same dataset, see: https://pytorch.org/docs/stable/fsdp.html
+        """
+        if rank==0:
+            torch.save(cpu_state_dict,os.path.join(output_dir,"model_weights.pt"))
+            tokenizer.save_pretrained(output_dir)

--- a/24_fsx_modeltrainer/smddp_fsdp_example.ipynb
+++ b/24_fsx_modeltrainer/smddp_fsdp_example.ipynb
@@ -1,0 +1,472 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# Train Falcon model using SageMaker SDK v3 ModelTrainer with FSx Lustre + FSDP\n",
+    "\n",
+    "---\n",
+    "\n",
+    "This notebook demonstrates how to train/fine-tune [Falcon-7B](https://huggingface.co/tiiuae/falcon-7b) on the [GLUE/SST2](https://huggingface.co/datasets/glue/viewer/sst2/train) dataset using:\n",
+    "\n",
+    "- **SageMaker Python SDK v3 `ModelTrainer` API** (replaces the legacy `PyTorch` Estimator)\n",
+    "- **FSx for Lustre** as the high-performance data source (synced with S3)\n",
+    "- **PyTorch FSDP** for distributed training across multiple GPUs\n",
+    "- **Torchrun** distribution via ModelTrainer's `distributed` config\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "1. Deploy the CloudFormation stack (`cfn-vpc-fsx-lustre.yaml`) to create VPC, subnet, security group, and FSx Lustre filesystem linked to your S3 bucket.\n",
+    "2. Upload your preprocessed training data to the linked S3 bucket so it syncs to FSx automatically.\n",
+    "\n",
+    "## Files\n",
+    "\n",
+    "* `scripts/train.py` \u2014 Training entry point with FSDP\n",
+    "* `scripts/utils.py` \u2014 Helper for dataloaders and model saving\n",
+    "* `scripts/requirements.txt` \u2014 Dependencies"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-1",
+   "metadata": {},
+   "source": [
+    "## 1. Getting started\n",
+    "\n",
+    "Install the SageMaker Python SDK v3 and dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install \"sagemaker>=3.0\" \"transformers\" \"datasets[s3]\" \"boto3\" --upgrade"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -r scripts/requirements.txt "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-4",
+   "metadata": {},
+   "source": [
+    "## 2. Session setup and CloudFormation stack outputs\n",
+    "\n",
+    "Initialize the SageMaker session and retrieve FSx Lustre, networking, and S3 configuration from the deployed CloudFormation stack. Set `STACK_NAME` to match the name you used when deploying `cfn-vpc-fsx-lustre.yaml`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import boto3\n",
+    "from sagemaker.core.helper.session_helper import Session, get_execution_role\n",
+    "from sagemaker.core.utils.utils import SageMakerClient\n",
+    "\n",
+    "os.environ[\"AWS_PROFILE\"] = \"claude\"\n",
+    "os.environ[\"AWS_DEFAULT_REGION\"] = \"us-west-2\"\n",
+    "os.environ[\"AWS_DEFAULT_PROFILE\"] = \"claude\"\n",
+    "os.environ.pop(\"AWS_SESSION_TOKEN\", None)\n",
+    "\n",
+    "# Reset the SDK's singleton client so it picks up the correct credentials\n",
+    "SageMakerClient.reset()\n",
+    "\n",
+    "region = \"us-west-2\"\n",
+    "boto_session = boto3.Session(profile_name=\"claude\", region_name=region)\n",
+    "sm_client = boto_session.client(\"sagemaker\")\n",
+    "session = Session(boto_session=boto_session, sagemaker_client=sm_client)\n",
+    "\n",
+    "print(f\"SageMaker role ARN: {role}\")\n",
+    "print(f\"Region: {region}\")\n",
+    "\n",
+    "# --- Read CloudFormation stack outputs ---\n",
+    "STACK_NAME = \"fsx-setup\"  # <-- Change this to your CloudFormation stack name\n",
+    "\n",
+    "cfn = boto_session.client(\"cloudformation\")\n",
+    "outputs = cfn.describe_stacks(StackName=STACK_NAME)[\"Stacks\"][0][\"Outputs\"]\n",
+    "stack_outputs = {o[\"OutputKey\"]: o[\"OutputValue\"] for o in outputs}\n",
+    "\n",
+    "FSX_FILE_SYSTEM_ID = stack_outputs[\"FileSystemId\"]\n",
+    "FSX_MOUNT_NAME = stack_outputs[\"MountName\"]\n",
+    "SUBNET_ID = stack_outputs[\"SubnetId\"]\n",
+    "SECURITY_GROUP_ID = stack_outputs[\"SecurityGroupId\"]\n",
+    "S3_BUCKET = stack_outputs[\"S3BucketLinked\"]\n",
+    "\n",
+    "FSX_DIRECTORY_PATH = f\"/{FSX_MOUNT_NAME}\"\n",
+    "\n",
+    "print(f\"\\nCloudFormation stack: {STACK_NAME}\")\n",
+    "print(f\"  S3 Bucket (FSx-linked): {S3_BUCKET}\")\n",
+    "print(f\"  FSx File System ID:     {FSX_FILE_SYSTEM_ID}\")\n",
+    "print(f\"  FSx Mount Name:         {FSX_MOUNT_NAME}\")\n",
+    "print(f\"  Subnet ID:              {SUBNET_ID}\")\n",
+    "print(f\"  Security Group ID:      {SECURITY_GROUP_ID}\")\n",
+    "print(f\"  Directory Path:         {FSX_DIRECTORY_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "role"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-6",
+   "metadata": {},
+   "source": [
+    "## 3. Load and prepare the dataset\n",
+    "\n",
+    "We use the [GLUE/SST2](https://huggingface.co/datasets/glue/viewer/sst2/train) dataset, tokenize it, and chunk into 2048-token blocks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_id = \"tiiuae/falcon-7b\"\n",
+    "dataset_name = \"glue\"\n",
+    "dataset_config = \"sst2\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datasets import load_dataset\n",
+    "from transformers import AutoTokenizer\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_id)\n",
+    "dataset = load_dataset(dataset_name, dataset_config)\n",
+    "dataset = dataset.shuffle(42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if \"validation\" not in dataset.keys():\n",
+    "    dataset[\"validation\"] = load_dataset(dataset_name, split=\"train[:5%]\")\n",
+    "    dataset[\"train\"] = load_dataset(dataset_name, split=\"train[5%:]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from itertools import chain\n",
+    "from functools import partial\n",
+    "\n",
+    "\n",
+    "def group_texts(examples, block_size=2048):\n",
+    "    concatenated_examples = {k: list(chain(*examples[k])) for k in examples.keys()}\n",
+    "    total_length = len(concatenated_examples[list(examples.keys())[0]])\n",
+    "    if total_length >= block_size:\n",
+    "        total_length = (total_length // block_size) * block_size\n",
+    "    result = {\n",
+    "        k: [t[i : i + block_size] for i in range(0, total_length, block_size)]\n",
+    "        for k, t in concatenated_examples.items()\n",
+    "    }\n",
+    "    result[\"labels\"] = result[\"input_ids\"].copy()\n",
+    "    return result\n",
+    "\n",
+    "\n",
+    "column_names = dataset[\"train\"].column_names\n",
+    "text_column_name = \"text\" if \"text\" in column_names else column_names[0]\n",
+    "\n",
+    "lm_dataset = dataset.map(\n",
+    "    lambda sample: tokenizer(sample[text_column_name]),\n",
+    "    batched=True,\n",
+    "    remove_columns=list(column_names),\n",
+    "    desc=\"Running tokenizer on dataset\",\n",
+    ").map(\n",
+    "    partial(group_texts, block_size=2048),\n",
+    "    batched=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-11",
+   "metadata": {},
+   "source": [
+    "## 4. Upload data to S3\n",
+    "\n",
+    "Save the tokenized dataset to S3. If using FSx Lustre linked to this bucket, the data will be automatically available on the filesystem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_data_path = f\"s3://{S3_BUCKET}/processed/data/\"\n",
+    "storage_options = {\"profile\": \"claude\"}\n",
+    "\n",
+    "print(f\"Saving training dataset to: {s3_data_path}\")\n",
+    "lm_dataset.save_to_disk(s3_data_path, storage_options=storage_options)\n",
+    "print(f\"Uploaded data to: {s3_data_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-13",
+   "metadata": {},
+   "source": [
+    "## 5. Configure and launch training with ModelTrainer\n",
+    "\n",
+    "We use the SageMaker SDK v3 `ModelTrainer` API with:\n",
+    "- `FileSystemDataSource` for FSx Lustre input channel\n",
+    "- `Torchrun` distributed config for multi-GPU FSDP training\n",
+    "- `Networking` config for VPC/subnet/security group (must match FSx Lustre placement)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from sagemaker.train import ModelTrainer\n",
+    "from sagemaker.core.training.configs import (\n",
+    "    SourceCode,\n",
+    "    Compute,\n",
+    "    Networking,\n",
+    "    InputData,\n",
+    "    OutputDataConfig,\n",
+    "    StoppingCondition,\n",
+    "    FileSystemDataSource,\n",
+    ")\n",
+    "from sagemaker.train.distributed import Torchrun\n",
+    "\n",
+    "# --- Training image (PyTorch 2.0+ GPU DLC for your region) ---\n",
+    "training_image = f\"763104351884.dkr.ecr.{region}.amazonaws.com/pytorch-training:2.0.1-gpu-py310-cu118-ubuntu20.04-sagemaker\"\n",
+    "\n",
+    "# --- Source code ---\n",
+    "source_code = SourceCode(\n",
+    "    source_dir=\"./scripts\",\n",
+    "    entry_script=\"train.py\",\n",
+    "    requirements=\"requirements.txt\",\n",
+    ")\n",
+    "\n",
+    "# --- Compute: 2x ml.g5.12xlarge (4 GPUs each) ---\n",
+    "compute = Compute(\n",
+    "    instance_type=\"ml.g5.2xlarge\",\n",
+    "    instance_count=1,\n",
+    "    volume_size_in_gb=400,\n",
+    ")\n",
+    "\n",
+    "# --- Networking: must match FSx Lustre VPC/subnet ---\n",
+    "networking = Networking(\n",
+    "    subnets=[SUBNET_ID],\n",
+    "    security_group_ids=[SECURITY_GROUP_ID],\n",
+    "    enable_network_isolation=False,\n",
+    "    enable_inter_container_traffic_encryption=True,\n",
+    ")\n",
+    "\n",
+    "# --- Distributed: Torchrun with 4 GPUs per node ---\n",
+    "distributed = Torchrun(process_count_per_node=4)\n",
+    "\n",
+    "# --- FSx Lustre data channel ---\n",
+    "fsx_train_input = InputData(\n",
+    "    channel_name=\"train\",\n",
+    "    data_source=FileSystemDataSource(\n",
+    "        file_system_id=FSX_FILE_SYSTEM_ID,\n",
+    "        file_system_access_mode=\"ro\",\n",
+    "        file_system_type=\"FSxLustre\",\n",
+    "        directory_path=FSX_DIRECTORY_PATH,\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "# --- Hyperparameters ---\n",
+    "hyperparameters = {\n",
+    "    \"model_id\": model_id,\n",
+    "    \"dataset_path\": \"/opt/ml/input/data/train\",\n",
+    "    \"gradient_checkpointing\": True,\n",
+    "    \"bf16\": True,\n",
+    "    \"optimizer\": \"adamw_torch\",\n",
+    "    \"per_device_train_batch_size\": 1,\n",
+    "    \"epochs\": 1,\n",
+    "    \"fsdp\": \"full_shard auto_wrap\",\n",
+    "    \"max_steps\": 30,\n",
+    "}\n",
+    "\n",
+    "# --- Output config ---\n",
+    "output_data_config = OutputDataConfig(\n",
+    "    s3_output_path=f\"s3://{S3_BUCKET}/falcon-fsdp-output/\",\n",
+    ")\n",
+    "\n",
+    "# --- Stopping condition ---\n",
+    "stopping_condition = StoppingCondition(max_runtime_in_seconds=3600)\n",
+    "\n",
+    "# --- Assemble ModelTrainer ---\n",
+    "model_trainer = ModelTrainer(\n",
+    "    training_image=training_image,\n",
+    "    source_code=source_code,\n",
+    "    distributed=distributed,\n",
+    "    compute=compute,\n",
+    "    networking=networking,\n",
+    "    hyperparameters=hyperparameters,\n",
+    "    input_data_config=[fsx_train_input],\n",
+    "    output_data_config=output_data_config,\n",
+    "    stopping_condition=stopping_condition,\n",
+    "    environment={\"NCCL_DEBUG\": \"INFO\"},\n",
+    "    role=role,\n",
+    "    sagemaker_session=session,\n",
+    "    base_job_name=\"falcon-fsdp-fsx\",\n",
+    ")\n",
+    "\n",
+    "print(\"ModelTrainer configured successfully.\")\n",
+    "print(f\"  Image: {training_image}\")\n",
+    "print(f\"  Compute: {compute.instance_count}x {compute.instance_type}\")\n",
+    "print(f\"  FSx filesystem: {FSX_FILE_SYSTEM_ID}\")\n",
+    "print(f\"  Distribution: Torchrun (4 procs/node)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-16",
+   "metadata": {},
+   "source": [
+    "### Launch the training job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "cell-17",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "model_trainer.train(wait=True, logs=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-18",
+   "metadata": {},
+   "source": [
+    "## 6. Expected Output\n",
+    "\n",
+    "After training begins, you should see output similar to:\n",
+    "\n",
+    "```\n",
+    "4%|\u258d         | 1/25 [00:08<03:29,  8.72s/it]\n",
+    "...\n",
+    "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 25/25 [00:41<00:00,  1.65s/it]\n",
+    "******epoch=0: train_ppl=tensor(43260.7148, device='cuda:0') train_loss=tensor(10.6750, device='cuda:0')******\n",
+    "*******epoch=0: eval_ppl=tensor(nan, device='cuda:0') eval_loss=tensor(nan, device='cuda:0')*******\n",
+    "Training done!\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-19",
+   "metadata": {},
+   "source": [
+    "## 7. (Alternative) Using S3 data source instead of FSx\n",
+    "\n",
+    "If you don't have FSx Lustre set up, you can use an S3 data source directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Alternative: S3 data channel (no FSx required, no networking config needed)\n",
+    "# from sagemaker.core.training.configs import InputData\n",
+    "#\n",
+    "# s3_train_input = InputData(\n",
+    "#     channel_name=\"train\",\n",
+    "#     data_source=s3_data_path,\n",
+    "# )\n",
+    "#\n",
+    "# model_trainer_s3 = ModelTrainer(\n",
+    "#     training_image=training_image,\n",
+    "#     source_code=source_code,\n",
+    "#     distributed=distributed,\n",
+    "#     compute=compute,\n",
+    "#     hyperparameters=hyperparameters,\n",
+    "#     input_data_config=[s3_train_input],\n",
+    "#     output_data_config=output_data_config,\n",
+    "#     stopping_condition=stopping_condition,\n",
+    "#     role=role,\n",
+    "#     sagemaker_session=session,\n",
+    "#     base_job_name=\"falcon-fsdp-s3\",\n",
+    "# )\n",
+    "# model_trainer_s3.train(wait=True, logs=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

- Adds `24_fsx_modeltrainer/` project demonstrating Falcon-7B fine-tuning with PyTorch FSDP using the SageMaker SDK v3 ModelTrainer API and FSx for Lustre
- Includes CloudFormation template (`cfn-vpc-fsx-lustre.yaml`) for provisioning VPC, subnet, security group, and FSx Lustre filesystem linked to S3
- Notebook reads all infrastructure config (FSx, networking, S3 bucket) dynamically from CloudFormation stack outputs

## Contents

- `smddp_fsdp_example.ipynb` — End-to-end notebook (data prep → upload → training)
- `cfn-vpc-fsx-lustre.yaml` — Infrastructure-as-code for FSx Lustre setup
- `scripts/train.py` — FSDP training entry point
- `scripts/utils.py` — DataLoader and model save helpers
- `scripts/requirements.txt` — Dependencies

## Test plan

- [ ] Deploy CloudFormation stack in target region
- [ ] Run notebook cells sequentially to verify training job launches
- [ ] Confirm FSx Lustre data channel mounts correctly on training instances